### PR TITLE
Include a link to a list of images

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,4 +11,5 @@ layout: default
       </li>
   </ul>
 
+  <p>See the <a href="https://microbadger.com/labelschema">list of public images</a> already using the label-schema convention</p>
 </div>


### PR DESCRIPTION
We have a list of images using at least one label-schema label on MicroBadger - would be nice to link to it from the label-schema.org page