### PR TITLE
Make deprecation notice URL more helpful

### DIFF
--- a/rc1.md
+++ b/rc1.md
@@ -7,7 +7,7 @@ permalink: /rc1/
 
 * Canonical URL: `http://label-schema.org/rc1/`
 * Version: 1.0.0-rc.1
-* Status: DEPRECATED IN FAVOUR OF [OCI IMAGE SPEC](https://github.com/opencontainers/image-spec)
+* Status: DEPRECATED IN FAVOUR OF [OCI IMAGE SPEC: ANNOTATIONS](https://github.com/opencontainers/image-spec/blob/v1.0.1/annotations.md)
 
 ### Maintainers:
 * Liz Rice <liz@lizrice.com>


### PR DESCRIPTION
By deep linking to the relevant part of the OCI Image Spec